### PR TITLE
refactor(jsonlayout): maintain layout even if data in logger context

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ TsLogDebug use docsify to convert markdown to HTML. In addition, all documentati
 the Api documentation. To preview your comments on a class you can run this command:
 
 ```
-npm run doc:serve
+npm run docs:serve
 ```
 
 ## Guidelines

--- a/packages/logger/src/common/layouts/components/JsonLayout.spec.ts
+++ b/packages/logger/src/common/layouts/components/JsonLayout.spec.ts
@@ -1,7 +1,7 @@
+import {LogContext} from "../../core/LogContext";
 import {LogEvent} from "../../core/LogEvent";
 import {levels} from "../../core/LogLevel";
 import {JsonLayout} from "./JsonLayout";
-import {LogContext} from "../../core/LogContext";
 
 describe("JsonLayout", () => {
   describe("when separator is given", () => {
@@ -21,10 +21,10 @@ describe("JsonLayout", () => {
       // @ts-ignore
       expect(result).toEqual(
         JSON.stringify({
-          user: "romain",
           startTime: logEvent.startTime,
           categoryName: "category",
           level: "DEBUG",
+          user: "romain",
           data: ["data"]
         }) + ","
       );
@@ -55,10 +55,10 @@ describe("JsonLayout", () => {
       // @ts-ignore
       expect(result).toEqual(
         JSON.stringify({
-          user: "romain",
           startTime: logEvent.startTime,
           categoryName: "category",
           level: "DEBUG",
+          user: "romain",
           test: "test",
           data: ["hello"]
         }) + ","
@@ -83,10 +83,10 @@ describe("JsonLayout", () => {
     it("should return a formatted string", () => {
       expect(result).toEqual(
         JSON.stringify({
-          user: "romain",
           startTime: logEvent._startTime,
           categoryName: "category",
           level: "DEBUG",
+          user: "romain",
           data: ["data"]
         })
       );

--- a/packages/logger/src/common/layouts/components/JsonLayout.spec.ts
+++ b/packages/logger/src/common/layouts/components/JsonLayout.spec.ts
@@ -92,4 +92,35 @@ describe("JsonLayout", () => {
       );
     });
   });
+
+  describe("startTime, categoryName, level  can't be overridden", () => {
+    let logEvent: any, layout: any, result: any;
+    beforeAll(() => {
+      layout = new JsonLayout({
+        type: "json"
+      });
+
+      const context = new LogContext();
+      context.set("user", "romain");
+      context.set("startTime", new Date());
+      context.set("categoryName", "fakeCategory");
+      context.set("level", levels().INFO);
+
+      logEvent = new LogEvent("category", levels().DEBUG, ["data"], context);
+      logEvent._startTime = new Date("2017-06-18 22:29:38.234");
+      result = layout.transform(logEvent);
+    });
+
+    it("should return a formatted string", () => {
+      expect(result).toEqual(
+        JSON.stringify({
+          startTime: logEvent._startTime,
+          categoryName: "category",
+          level: "DEBUG",
+          user: "romain",
+          data: ["data"]
+        })
+      );
+    });
+  });
 });

--- a/packages/logger/src/common/layouts/utils/logEventToObject.ts
+++ b/packages/logger/src/common/layouts/utils/logEventToObject.ts
@@ -3,11 +3,15 @@ import {LogEvent} from "../../core/LogEvent";
 import {removeColors} from "./colorizeUtils";
 
 export function logEventToObject(loggingEvent: LogEvent) {
+  const contextObject = loggingEvent.context.toJSON();
+  const contextWithoutstartTime = excludeKey(contextObject, "startTime");
+  const contextWithoutcategoryName = excludeKey(contextWithoutstartTime, "categoryName");
+  const contextToLog = excludeKey(contextWithoutcategoryName, "level");
   const log: any = {
     startTime: loggingEvent.startTime,
     categoryName: loggingEvent.categoryName,
     level: loggingEvent.level.toString(),
-    ...loggingEvent.context.toJSON()
+    ...contextToLog
   };
 
   log.data = loggingEvent.data.reduce((data, current) => {
@@ -25,4 +29,9 @@ export function logEventToObject(loggingEvent: LogEvent) {
   }, []);
 
   return log;
+}
+
+function excludeKey<T extends object, U extends keyof any>(obj: T, key: U) {
+  const {[key]: _, ...newObj} = obj;
+  return newObj;
 }

--- a/packages/logger/src/common/layouts/utils/logEventToObject.ts
+++ b/packages/logger/src/common/layouts/utils/logEventToObject.ts
@@ -4,10 +4,10 @@ import {removeColors} from "./colorizeUtils";
 
 export function logEventToObject(loggingEvent: LogEvent) {
   const log: any = {
-    ...loggingEvent.context.toJSON(),
     startTime: loggingEvent.startTime,
     categoryName: loggingEvent.categoryName,
-    level: loggingEvent.level.toString()
+    level: loggingEvent.level.toString(),
+    ...loggingEvent.context.toJSON()
   };
 
   log.data = loggingEvent.data.reduce((data, current) => {


### PR DESCRIPTION
## Informations

| Type                  |  Status                   | Migration |
| --------------- | ------------------ | ----------|
| Refactor            | Ready                    | No            |

---

## Description

- keep startTime, categoryName and level at the beginning of Json object when using Json Layout:
  _This makes it easier to track logs_

- minor fix in CONTRIBUTING.md

## Example

**Before:**

without additional data in logger context:
{"startTime":"2024-07-10T16:29:22.398Z","categoryName":"TSED","level":"INFO",..., "data":[]}

with additional data in logger context
`const context = new LogContext();
      context.set("user", "romain");`
{"user": romain", "startTime":"2024-07-10T16:29:22.398Z","categoryName":"TSED","level":"INFO",..., "data":[]}

**After:**

with additional data in logger context
{"startTime":"2024-07-10T16:29:22.398Z","categoryName":"TSED","level":"INFO", "user": romain", ..., "data":[]}


## Todos

- [X ] Tests
- [X] Coverage
- [X] Example
- [] Documentation
