### PR TITLE
docs: Update CONTRIBUTING.md for `yarn` instead of `npm`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,19 +11,19 @@ $ git clone https://github.com/YOUR_USERNAME/logger.git
 Install npm dependencies
 
 ```
-npm install
+yarn
 ```
 
 Run build process
 
 ```
-npm run tsc:compile
+yarn build
 ```
 
 ## Test
 
 ```
-npm run test
+yarn test
 ```
 
 ## Write documentation
@@ -32,7 +32,7 @@ TsLogDebug use docsify to convert markdown to HTML. In addition, all documentati
 the Api documentation. To preview your comments on a class you can run this command:
 
 ```
-npm run doc:serve
+yarn docs:serve
 ```
 
 ## Guidelines


### PR DESCRIPTION
## Informations

| Type                  |  Status                   | Migration |
| --------------------- | ------------------------- | --------- |
| Chore | Ready | No    |

---

## Description

Updates the documentation for contributing. `npm` doesn't even work.

Also: Should the link to https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit simply be replaced by a link to conventional commits (https://www.conventionalcommits.org/en/v1.0.0-beta.4/)?

